### PR TITLE
Added failing example2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ $ npm install
 To test a rule in isolation with `eslint`, run a command similar to:
 
 ```shell
-$ ./node-modules/eslint/bin/eslint.js --reset --no-eslintrc \
+$ ./node_modules/eslint/bin/eslint.js --reset --no-eslintrc \
   --rule "'ng-annotate-arg-order': 1" \
   --rulesdir ./lib/rules \
-  tests/example1.js
+  tests/*.js
 ```
 
 Then, edit [example1.js](https://github.com/smt/eslint-plugin-smt/blob/master/tests/example1.js) to make it fail the rule.

--- a/lib/rules/ng-annotate-arg-order.js
+++ b/lib/rules/ng-annotate-arg-order.js
@@ -13,7 +13,7 @@ module.exports = function ngAnnotateArgOrder (context) {
     return {
         AssignmentExpression: function assignExp (node) {
             var source = context.getSource(node.left, 0, 16);
-            if (source.match(/module\.exports = \/\*@ngInject\*\//) && node.right.type === 'FunctionExpression') {
+            if (/module\.exports = \/\*@ngInject\*\//.test(source) && node.right.type === 'FunctionExpression') {
                 node.right.params.reduce(function paramsReducer (prev, param) {
                     if (prev.name > param.name) {
                         context.report(node, 'Found argument identifier out of alphabetical order');

--- a/tests/example2.js
+++ b/tests/example2.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = /*@ngInject*/
+function exports (
+    b,
+    a,
+    c
+) {
+    return a + b + c;
+};


### PR DESCRIPTION
Fixed typo in README shell example. Changed string match() call to a regex test() call.
